### PR TITLE
OT133-83 - Agregar paginación a Testimonios

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.controller;
 
 import java.net.URI;
+import java.util.List;
 import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.dto.TestimonialIDDTO;
 import com.alkemy.ong.service.TestimonialService;
@@ -9,7 +10,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
@@ -25,6 +34,12 @@ public class TestimonialController extends BaseController {
   // --------------------------------------------------------------------------------------------
   // Get
   // --------------------------------------------------------------------------------------------
+
+  @GetMapping(produces = "application/json")
+  public ResponseEntity<List<TestimonialDTO>> read(@RequestParam(required = false) Integer page) {
+
+    return ResponseEntity.ok(testimonialService.read(page));
+  }
 
   // --------------------------------------------------------------------------------------------
   // Post

--- a/src/main/java/com/alkemy/ong/repository/TestimonialRepository.java
+++ b/src/main/java/com/alkemy/ong/repository/TestimonialRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TestimonialRepository extends JpaRepository<Testimonial, String> {
+
 }

--- a/src/main/java/com/alkemy/ong/service/TestimonialService.java
+++ b/src/main/java/com/alkemy/ong/service/TestimonialService.java
@@ -1,9 +1,12 @@
 package com.alkemy.ong.service;
 
+import java.util.List;
 import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.dto.TestimonialIDDTO;
 
 public interface TestimonialService {
+
+  List<TestimonialDTO> read(Integer page);
 
   TestimonialIDDTO create(TestimonialDTO dto);
 

--- a/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
@@ -1,5 +1,8 @@
 package com.alkemy.ong.service.impl;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.persistence.EntityNotFoundException;
 import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.dto.TestimonialIDDTO;
@@ -8,10 +11,14 @@ import com.alkemy.ong.mapper.TestimonialMapper;
 import com.alkemy.ong.repository.TestimonialRepository;
 import com.alkemy.ong.service.TestimonialService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TestimonialServiceImpl implements TestimonialService {
+
+  private static final int PAGE_SIZE = 10;
 
   @Autowired
   private TestimonialMapper testimonialMapper;
@@ -38,6 +45,20 @@ public class TestimonialServiceImpl implements TestimonialService {
     return testimonialMapper.toDTO(testimonial);
   }
 
+
+  public List<TestimonialDTO> read(Integer page) {
+
+    if (Objects.isNull(page)) {
+      return testimonialRepository.findAll().stream().map(testimonialMapper::toDTO)
+          .collect(Collectors.toList());
+    }
+
+    Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+
+    return testimonialRepository.findAll(pageable).getContent().stream()
+        .map(testimonialMapper::toDTO).collect(Collectors.toList());
+  }
   // --------------------------------------------------------------------------------------------
   // Update
   // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

**COMO** usuario
**QUIERO** visualizar los resultados de Testimonios paginados
**PARA** aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page