### PR TITLE
OT133-101-Bug: Security Configuration

### DIFF
--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -42,57 +42,49 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Value("${security.token.validator-secret}")
   private String tokenSecret;
-  
+
   @Autowired
   private RESTAuthenticationEntryPoint authenticationEntryPoint;
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
-	  try {
-    TokenValidator tokenValidator = new TokenValidator(tokenSecret);
+    try {
+      TokenValidator tokenValidator = new TokenValidator(tokenSecret);
 
-    // Set Filter URL
-    TokenAuthenticationFilter tokenAuthenticationFilter =
-        new TokenAuthenticationFilter(authenticationManagerBean(), tokenValidator);
-    tokenAuthenticationFilter.setFilterProcessesUrl("/auth/login");
+      // Set Filter URL
+      TokenAuthenticationFilter tokenAuthenticationFilter =
+          new TokenAuthenticationFilter(authenticationManagerBean(), tokenValidator);
+      tokenAuthenticationFilter.setFilterProcessesUrl("/auth/login");
 
-    // Habilita CORS y desactiva CSRF
-    http.cors().and()
-    .csrf().disable();
+      // Habilita CORS y desactiva CSRF
+      http.cors().and().csrf().disable();
 
-    // Seteo de session management a stateless
-    http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-    .authorizeRequests().antMatchers(HttpMethod.GET,"/**").hasAnyAuthority("ROL_ADMIN", "ROL_USER")
-    					.antMatchers(HttpMethod.POST, "/**").hasAuthority("ROL_ADMIN")
-    					.antMatchers(HttpMethod.PUT, "/**").hasAuthority("ROL_ADMIN")
-    					.antMatchers(HttpMethod.DELETE, "/**").hasAuthority("ROL_ADMIN")
-    					.and()
-	.requestCache().requestCache(new NullRequestCache()).and()
-	.httpBasic().authenticationEntryPoint(authenticationEntryPoint).and()
-	.cors().and()
-	.csrf().disable();
-    
-        
-    // Permitir todo en /**/auth/**
-    http.authorizeRequests().antMatchers(AUTH_WHITELIST).permitAll().anyRequest()
-        // El Resto de las rutas, requeriran autenticación
-        .authenticated();
+      // Permitir todo en /**/auth/**
+      http.authorizeRequests().antMatchers(AUTH_WHITELIST).permitAll().anyRequest()
+          // El Resto de las rutas, requeriran autenticación
+          .authenticated();
 
-    
-    // Add JWT Token Authorization filter
-    http.addFilterBefore(new TokenAuthorizationFilter(tokenValidator),
-        UsernamePasswordAuthenticationFilter.class);
-    
-    // Add JWT Token Authentication filter
-    http.addFilter(tokenAuthenticationFilter);
-    
-    
-	} catch (Exception ex) {
-		ex.getMessage();
-	}
+      // Seteo de session management a stateless
+      http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+          .authorizeRequests().antMatchers(HttpMethod.GET, "/**")
+          .hasAnyAuthority("ROL_ADMIN", "ROL_USER").antMatchers(HttpMethod.POST, "/**")
+          .hasAuthority("ROL_ADMIN").antMatchers(HttpMethod.PUT, "/**").hasAuthority("ROL_ADMIN")
+          .antMatchers(HttpMethod.DELETE, "/**").hasAuthority("ROL_ADMIN").and().requestCache()
+          .requestCache(new NullRequestCache()).and().httpBasic()
+          .authenticationEntryPoint(authenticationEntryPoint);
 
-    
-    
+      // Add JWT Token Authorization filter
+      http.addFilterBefore(new TokenAuthorizationFilter(tokenValidator),
+          UsernamePasswordAuthenticationFilter.class);
+
+      // Add JWT Token Authentication filter
+      http.addFilter(tokenAuthenticationFilter);
+
+
+    } catch (Exception ex) {
+      ex.getMessage();
+    }
+
   }
 
   @Override


### PR DESCRIPTION
Los matchers estaban mal organizados.

Se bloqueaban los POST a los paths `"/**"` antes que la whitelist de seguridad.

Estas restricciones matchean segun el orden en el que son declaradas:

```
- "/**"                            - Post solo admin
- "/auth/**                        - Cualquier request
```


Entonces el path `"/auth/"` matchea con la primera opcion.

El arreglo fue cambiar el orden en el que esto sucede, dejandolo:

```
- "/auth/**                        - Cualquier request
- "/**"                            - Post solo admin
```
